### PR TITLE
Add rest option to WorkCommand

### DIFF
--- a/src/Console/WorkCommand.php
+++ b/src/Console/WorkCommand.php
@@ -25,6 +25,7 @@ class WorkCommand extends BaseWorkCommand
                             {--stop-when-empty : Stop when the queue is empty}
                             {--queue= : The names of the queues to work}
                             {--sleep=3 : Number of seconds to sleep when no job is available}
+                            {--rest=0 : Number of seconds to rest between jobs}
                             {--supervisor= : The name of the supervisor the worker belongs to}
                             {--timeout=60 : The number of seconds a child process can run}
                             {--tries=0 : Number of times to attempt a job before logging it failed}';


### PR DESCRIPTION
This merge request adds a 'rest' option to the WorkCommand and therefore fixes following issue:
https://github.com/carsguide/lumen-horizon/issues/12

See also a commit in the Laravel Horizon project:
https://github.com/laravel/horizon/commit/fcb98431ff4ba0a59ab99f1c6bebe8b7115f328a